### PR TITLE
fix: correct typos in stdin message and empty-input error

### DIFF
--- a/AGENTS-tasks.md
+++ b/AGENTS-tasks.md
@@ -72,32 +72,6 @@ var _ = Describe("PsaEvaluator Error Handling", func() {
 
 ---
 
-### 1.2 Fix Typos in client.go
-
-**Location:** `pkg/analyzer/client.go` lines 44 and 55
-
-**Why:** Typos in user-facing messages and error messages reduce professionalism and can confuse users.
-
-**How to Implement:**
-1. Line 44: Change `"Reading from stdinv\n"` to `"Reading from stdin\n"`
-2. Line 55: Change `errors.New("Empty imput stream")` to `errors.New("empty input stream")`
-
-**Testing:**
-- **E2E Test:** Add test case that pipes empty input and verifies correct error message
-- **Test File:** Add to `test/test-fail.sh`
-
-```bash
-# Test empty stdin input
-echo "" | ./release/psa-checker -f - -l baseline 2>&1 | grep -q "empty input stream"
-if [ $? -ne 0 ]; then
-    echo "FAIL: Empty stdin should return 'empty input stream' error"
-    exit 1
-fi
-echo "PASS: Empty stdin error message correct"
-```
-
----
-
 ### 1.3 Implement Structured Logging
 
 **Location:** Throughout `pkg/analyzer/psaEvaluator.go`
@@ -2232,7 +2206,7 @@ rootCmd.Flags().String("metrics-addr", "", "Address to expose Prometheus metrics
 
 This document outlines 30+ potential improvements organized into 7 categories:
 
-1. **Critical Bug Fixes** (4 tasks) - Foundation improvements for stability
+1. **Critical Bug Fixes** (3 tasks) - Foundation improvements for stability
 2. **Existing TODOs** (4 tasks) - Complete planned features
 3. **User Experience** (7 tasks) - Make tool more user-friendly and capable
 4. **Testing** (5 tasks) - Improve test coverage and quality assurance
@@ -2244,11 +2218,10 @@ This document outlines 30+ potential improvements organized into 7 categories:
 
 ### High Priority (Do First):
 1. Replace panic() with proper error handling (1.1)
-2. Fix typos (1.2)
-3. Configurable PSS version (2.1)
-4. JSON output format (3.1)
-5. Summary statistics (3.3)
-6. Error path testing (4.5)
+2. Configurable PSS version (2.1)
+3. JSON output format (3.1)
+4. Summary statistics (3.3)
+5. Error path testing (4.5)
 
 ### Medium Priority (Do Next):
 1. Structured logging (1.3)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Run `make lint test` before declaring work done on a Go change.
 
 ## Conventions
 
+- You are already executed from inside the project directory. Don't `cd` into the repo root before running commands — use paths relative to it and only if needed.
 - Keep changes minimal and focused; this is a small CLI, not a framework.
 - Don't introduce new dependencies without a clear reason — the upstream `pod-security-admission` package is the core dependency and should stay that way.
 - Preserve the existing CLI surface unless the user explicitly asks to change it (alpha, but users exist and CI pipelines depend on flags + exit codes).

--- a/pkg/analyzer/client.go
+++ b/pkg/analyzer/client.go
@@ -41,7 +41,7 @@ func (s *client) AnalyzeFile() (AnalyzerResponse, error) { //uppercase first let
 			return response, err
 		}
 	} else {
-		fmt.Printf("Reading from stdinv\n")
+		fmt.Printf("Reading from stdin\n")
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			input += scanner.Text() + "\n"
@@ -52,7 +52,7 @@ func (s *client) AnalyzeFile() (AnalyzerResponse, error) { //uppercase first let
 		stream = []byte(input)
 
 		if len(stream) == 0 {
-			return response, errors.New("Empty imput stream")
+			return response, errors.New("empty input stream")
 		}
 	}
 

--- a/test/test-fail.sh
+++ b/test/test-fail.sh
@@ -33,4 +33,9 @@ output=$(run_checker --filename nonexistent.yaml 2>&1)
 [ $? -ne 1 ] && exit 1
 if [[ "$output" != *"no such file or directory"* ]]; then exit 1; fi
 
+# Test for empty stdin input
+output=$(printf '' | run_checker --filename - --level baseline 2>&1)
+[ $? -ne 1 ] && exit 1
+if [[ "$output" != *"empty input stream"* ]]; then exit 1; fi
+
 echo "[ success ] Non compliant manifests succesfully flagged"


### PR DESCRIPTION
- "Reading from stdinv" -> "Reading from stdin"
- "Empty imput stream" -> "empty input stream" (lowercased to match Go error convention)
- Add e2e case for empty stdin in test/test-fail.sh
- Remove completed task 1.2 from AGENTS-tasks.md
- Note in AGENTS.md that agents should not use full path to cd into the repo root